### PR TITLE
Moves from Grafana Agent metrics to Tempo server-side metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ The configuration file (`prometheus/prometheus.yml`) defines several scrape jobs
 * Retrieving metrics from the Prometheus instance itself.
 * Metrics from the microservices application.
 * Metrics from the installed Node Exporter instance.
-* Metrics from the Grafana Agent, derived from incoming trace data.
+
+Additionally to the scraped metrics, it also receives remotely written metrics from the Tempo service, which derives metrics from incoming trace spans.
 
 ## Loki
 
@@ -94,6 +95,8 @@ The Tempo instance is described in the `tempo` section of the `docker-compose.ym
 
 The Tempo service imports a configuration file (`tempo/tempo.yaml`) that initialises the service with some sensible defaults as well as allowing the receiving of traces in a variety of different formats.
 
+As of Tempo 1.4, the ability to also automatically generate metrics from incoming trace spans is included. As such, this no longer occurs via Grafana Agent.
+
 ## Grafana Agent
 
 Grafana Agent is a locally installed agent that acts as:
@@ -103,6 +106,8 @@ Grafana Agent is a locally installed agent that acts as:
 
 Grafana Agent has remote write capabilities that allows it to send metrics, logs and trace data to backend stores (such as Mimir, Loki and Tempo). More information on Grafana Agent can be found [here](https://grafana.com/docs/agent/latest/).
 
-Its main role in this environment is to receive trace spans from the microservice application and process them to extract metrics and log information before storing them in the final backend stores.
+Its main role in this environment is to receive trace spans from the microservice application and process them to extract log information before storing them in the final backend stores.
+
+Note that the config now includes a commented section where metrics used to be generated from incoming trace spans; this is now handled directly in Tempo via server-side metrics generation, although the original configuration block has been left commented out in the Agent config.
 
 The configuration file for it can be found in `agent/config.yaml`.

--- a/agent/config.yaml
+++ b/agent/config.yaml
@@ -23,16 +23,17 @@ traces:
             endpoint: "0.0.0.0:6832"
     # Send batched traces to the Tempo instance.
     remote_write:
-      - endpoint: tempo:55680
+      - endpoint: tempo:4317
         insecure: true
     # Generate Prometheus metrics from the incoming trace spans.
-    spanmetrics:
-      # Add the http.target and http.method span tags as labels for the metrics data.
-      dimensions:
-        - name: http.method
-        - name: http.target
-      # Expose these metrics on port 12348.
-      handler_endpoint: 0.0.0.0:12348
+    # This now occurs as part of Tempo's server-side metrics generation.
+    #spanmetrics:
+    #  # Add the http.target and http.method span tags as labels for the metrics data.
+    #  dimensions:
+    #    - name: http.method
+    #    - name: http.target
+    #  # Expose these metrics on port 12348.
+    #  handler_endpoint: 0.0.0.0:12348
     # Generate logs automatically from incoming trace data.
     automatic_logging:
       # Use the logs instance defined at the start of the configuration file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,11 +98,19 @@ services:
     build: ./prometheus
     ports:
       - "9090:9090"
+    command: [
+      "--config.file=/etc/prometheus/prometheus.yml",
+      "--storage.tsdb.path=/prometheus",
+      "--web.console.libraries=/usr/share/prometheus/console_libraries",
+      "--web.console.templates=/usr/share/prometheus/consoles",
+      "--enable-feature=exemplar-storage",
+      "--web.enable-remote-write-receiver"
+    ]
 
   # The Tempo service stores traces send to it by Grafana Agent, and takes
   # queries from Grafana to visualise those traces.
   tempo:
-    image: grafana/tempo:1.2.1
+    image: grafana/tempo:1.4.0
     ports:
       - "3200:3200"
       - "4317:4317"

--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -70,7 +70,7 @@
             {
               "targetBlank": true,
               "title": "Latency charts",
-              "url": "http://localhost:3000/explore?orgId=1&left=[\"now-1h\",\"now\",\"Prometheus\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"expr\":\"topk(10, sum by (http_method,http_target)(increase(traces_spanmetrics_latency_sum{http_method!=\\\"\\\", http_target!=\\\"\\\"}[1m]) / increase(traces_spanmetrics_latency_count{http_method!=\\\"\\\", http_target!=\\\"\\\"}[1m])))\"}]&right=\n[\"now-1h\",\"now\",\"Tempo\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"queryType\":\"nativeSearch\",\"search\":\"http.target=${__field.labels.http_target} http.method=${__field.labels.http_method}\"}]"
+              "url": "http://localhost:3000/explore?orgId=1&left=[\"now-1h\",\"now\",\"Prometheus\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"expr\":\"topk(10, sum by (http_method,http_target)(increase(traces_spanmetrics_duration_seconds_sum{http_method!=\\\"\\\", http_target!=\\\"\\\"}[1m]) / increase(traces_spanmetrics_duration_seconds_count{http_method!=\\\"\\\", http_target!=\\\"\\\"}[1m])))\"}]&right=\n[\"now-1h\",\"now\",\"Tempo\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"queryType\":\"nativeSearch\",\"search\":\"http.target=${__field.labels.http_target} http.method=${__field.labels.http_method}\"}]"
             }
           ],
           "mappings": [],
@@ -115,7 +115,7 @@
             "uid": "prometheus"
           },
           "exemplar": true,
-          "expr": "sum by (http_target)(rate(traces_spanmetrics_latency_sum{http_target=~\".+\"}[1m]) / rate(traces_spanmetrics_latency_count{http_target=~\".+\"}[1m])) * 55",
+          "expr": "sum by (http_target)(rate(traces_spanmetrics_duration_seconds_sum{http_target=~\".+\"}[1m]) / rate(traces_spanmetrics_duration_seconds_count{http_target=~\".+\"}[1m])) * 55",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -178,7 +178,7 @@
             "uid": "prometheus"
           },
           "exemplar": true,
-          "expr": "(sum(increase(traces_spanmetrics_calls_total{status_code=\"STATUS_CODE_ERROR\"}[1m]))/sum(increase(traces_spanmetrics_calls_total[1m]))) * 100",
+          "expr": "(sum(increase(traces_spanmetrics_calls_total{span_status=\"STATUS_CODE_ERROR\"}[1m]))/sum(increase(traces_spanmetrics_calls_total[1m]))) * 100",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -250,7 +250,7 @@
             "uid": "prometheus"
           },
           "exemplar": true,
-          "expr": "(sum by (http_target)(increase(traces_spanmetrics_calls_total{status_code=\"STATUS_CODE_ERROR\",http_target=~\"\\\\/\\\\w+\"}[1m])))/(sum by (http_target)(increase(traces_spanmetrics_calls_total{status_code!=\"\",http_target!=\"\\\\/\\\\w+\"}[1m]))) * 100",
+          "expr": "(sum by (http_target)(increase(traces_spanmetrics_calls_total{span_status=\"STATUS_CODE_ERROR\",http_target=~\"\\\\/\\\\w+\"}[1m])))/(sum by (http_target)(increase(traces_spanmetrics_calls_total{span_status!=\"\",http_target!=\"\\\\/\\\\w+\"}[1m]))) * 100",
           "interval": "",
           "legendFormat": "{{http_target}}",
           "refId": "A"
@@ -282,6 +282,7 @@
               "url": "http://localhost:3000/explore?orgId=1&left=\n[\"now-1h\",\"now\",\"Tempo\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"queryType\":\"nativeSearch\",\"search\":\"http.target=${__data.fields.Endpoint} http.method=${__data.fields[\"HTTP Method\"]}\"}]"
             }
           ],
+          "unit": "s",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -345,7 +346,7 @@
             "uid": "prometheus"
           },
           "exemplar": false,
-          "expr": "topk(10, sum by (http_method,http_target)(increase(traces_spanmetrics_latency_sum{http_method=~\".+\", http_target=~\".+\"}[1m]) / increase(traces_spanmetrics_latency_count{http_method=~\".+\", http_target=~\".+\"}[1m])))",
+          "expr": "topk(10, sum by (http_method,http_target)(increase(traces_spanmetrics_duration_seconds_sum{http_method=~\".+\", http_target=~\".+\"}[1m]) / increase(traces_spanmetrics_duration_seconds_count{http_method=~\".+\", http_target=~\".+\"}[1m])))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -431,7 +432,7 @@
             {
               "targetBlank": true,
               "title": "Latency charts",
-              "url": "http://localhost:3000/explore?orgId=1&left=[\"now-1h\",\"now\",\"Prometheus\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"expr\":\"topk(10, sum by (http_method,http_target)(increase(traces_spanmetrics_latency_sum{http_method!=\\\"\\\", http_target!=\\\"\\\"}[1m]) / increase(traces_spanmetrics_latency_count{http_method!=\\\"\\\", http_target!=\\\"\\\"}[1m])))\"}]&right=\n[\"now-1h\",\"now\",\"Tempo\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"queryType\":\"nativeSearch\",\"search\":\"http.target=${__field.labels.http_target} http.method=${__field.labels.http_method}\"}]"
+              "url": "http://localhost:3000/explore?orgId=1&left=[\"now-1h\",\"now\",\"Prometheus\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"expr\":\"topk(10, sum by (http_method,http_target)(increase(traces_spanmetrics_duration_seconds_sum{http_method!=\\\"\\\", http_target!=\\\"\\\"}[1m]) / increase(traces_spanmetrics_duration_seconds_count{http_method!=\\\"\\\", http_target!=\\\"\\\"}[1m])))\"}]&right=\n[\"now-1h\",\"now\",\"Tempo\",{\"refId\":\"A\",\"instant\":true,\"range\":true,\"exemplar\":true,\"queryType\":\"nativeSearch\",\"search\":\"http.target=${__field.labels.http_target} http.method=${__field.labels.http_method}\"}]"
             }
           ],
           "mappings": [],
@@ -476,7 +477,7 @@
             "uid": "prometheus"
           },
           "exemplar": true,
-          "expr": "sum by (http_method,http_target)(increase(traces_spanmetrics_latency_sum{http_method=~\".+\", http_target=~\".+\"}[10m]) / increase(traces_spanmetrics_latency_count{http_method=~\".+\", http_target=~\".+\"}[10m]))",
+          "expr": "sum by (http_method,http_target)(increase(traces_spanmetrics_duration_seconds_sum{http_method=~\".+\", http_target=~\".+\"}[10m]) / increase(traces_spanmetrics_duration_seconds_count{http_method=~\".+\", http_target=~\".+\"}[10m]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -35,14 +35,6 @@ scrape_configs:
           group: 'resources'
 
   # Scrape from Grafana Agent, giving us metrics from traces it collects.
-  - job_name: 'span-metrics'
-    scrape_interval: 2s
-    static_configs:
-      - targets: ['agent:12348']
-        labels:
-          group: 'mythical'
-
-  # Scrape from Grafana Agent, giving us metrics from traces it collects.
   - job_name: 'agent-metrics'
     scrape_interval: 2s
     static_configs:

--- a/source/mythical-beasts-requester/index.js
+++ b/source/mythical-beasts-requester/index.js
@@ -34,7 +34,7 @@ const makeRequest = async () => {
     let error = false;
 
     // Create a new span
-    const requestSpan = tracer.startSpan("requester", { kind: api.SpanKind.CLIENT });
+    const requestSpan = tracer.startSpan('requester', { kind: api.SpanKind.CLIENT });
     requestSpan.setAttribute(spanTag, endpoint);
     const { traceId } = requestSpan.spanContext();
 
@@ -61,7 +61,7 @@ const makeRequest = async () => {
                     job: `${servicePrefix}-requester`,
                     endpointLabel: spanTag,
                     endpoint,
-                    message: `traceID=${traceId} http.method=GET endpoint=${endpoint}" status=SUCCESS`,
+                    message: `traceID=${traceId} http.method=GET endpoint=${endpoint} status=SUCCESS`,
                 });
                 names = JSON.parse(result);
 
@@ -82,7 +82,7 @@ const makeRequest = async () => {
                             job: `${servicePrefix}-requester`,
                             endpointLabel: spanTag,
                             endpoint,
-                            message: `traceID=${traceId} http.method=DELETE endpoint=${endpoint}" status=SUCCESS`,
+                            message: `traceID=${traceId} http.method=DELETE endpoint=${endpoint} status=SUCCESS`,
                         });
                     }
                 }
@@ -93,7 +93,7 @@ const makeRequest = async () => {
                     job: `${servicePrefix}-requester`,
                     endpointLabel: spanTag,
                     endpoint,
-                    message: `traceID=${traceId} http.method=DELETE endpoint=${endpoint} name=${(names) ? names[0].name : "unknown"} status=FAILURE error=${err}`,
+                    message: `traceID=${traceId} http.method=DELETE endpoint=${endpoint} name=${(names) ? names[0].name : 'unknown'} status=FAILURE error="${err}"`,
                 });
                 console.log('Requester error');
                 error = true;
@@ -101,7 +101,7 @@ const makeRequest = async () => {
         } else {
             // Generate new name
             const randomName = uniqueNamesGenerator({ dictionaries: [adjectives, colors, adjectives] });
-            const body = (Math.random() < 0.1) ? { whoops: "yes" } : { name : randomName };
+            const body = (Math.random() < 0.1) ? { whoops: 'yes' } : { name : randomName };
 
             try {
                 await request({
@@ -126,7 +126,7 @@ const makeRequest = async () => {
                     job: `${servicePrefix}-requester`,
                     endpointLabel: spanTag,
                     endpoint,
-                    message: `traceID=${traceId} http.method=POST endpoint=${endpoint} name=${randomName} status=FAILURE error=${err}`,
+                    message: `traceID=${traceId} http.method=POST endpoint=${endpoint} name=${randomName} status=FAILURE error="${err}"`,
                 });
                 console.log('Requester error');
                 error = true;

--- a/source/mythical-beasts-server/index.js
+++ b/source/mythical-beasts-server/index.js
@@ -123,7 +123,7 @@ app.get('/:endpoint', async (req, res) => {
 
     if (!nameSet.includes(endpoint)) {
         res.status(404).send(`${endpoint} is not a valid endpoint`);
-        metricBody.labels.status = "404";
+        metricBody.labels.status = '404';
         responseMetric(metricBody);
         return;
     }
@@ -146,7 +146,7 @@ app.get('/:endpoint', async (req, res) => {
         });
 
         // Metrics
-        metricBody.labels.status = "200";
+        metricBody.labels.status = '200';
         responseMetric(metricBody);
 
         logEntry({
@@ -160,7 +160,7 @@ app.get('/:endpoint', async (req, res) => {
 
         res.send(results);
     } catch (err) {
-        metricBody.labels.status = "500";
+        metricBody.labels.status = '500';
         responseMetric(metricBody);
 
         logEntry({
@@ -169,7 +169,7 @@ app.get('/:endpoint', async (req, res) => {
             job: `${servicePrefix}-server`,
             endpointLabel: spanTag,
             endpoint,
-            message: `traceID=${traceId} endpoint=${endpoint} http.method=GET status=FAILURE err=${err}`,
+            message: `traceID=${traceId} endpoint=${endpoint} http.method=GET status=FAILURE err="${err}"`,
         });
 
         res.status(500).send(err);
@@ -193,7 +193,7 @@ app.post('/:endpoint', async (req, res) => {
 
     if (!nameSet.includes(endpoint)) {
         res.status(404).send(`${endpoint} is not a valid endpoint`);
-        metricBody.labels.status = "404";
+        metricBody.labels.status = '404';
         responseMetric(metricBody);
         return;
     }
@@ -201,7 +201,7 @@ app.post('/:endpoint', async (req, res) => {
     if (!req.body || !req.body.name) {
         // Here we'd use 'respondToCall()' which would POST a metric for the response
         // code
-        metricBody.labels.status = "400";
+        metricBody.labels.status = '400';
         responseMetric(metricBody);
     }
 
@@ -224,7 +224,7 @@ app.post('/:endpoint', async (req, res) => {
         });
 
         // Metrics
-        metricBody.labels.status = "201";
+        metricBody.labels.status = '201';
         responseMetric(metricBody);
 
         logEntry({
@@ -239,8 +239,7 @@ app.post('/:endpoint', async (req, res) => {
         res.sendStatus(201);
     } catch (err) {
         // Metrics
-        console.log(`error: ${err}`);
-        metricBody.labels.status = "500";
+        metricBody.labels.status = '500';
         responseMetric(metricBody);
 
         logEntry({
@@ -249,7 +248,7 @@ app.post('/:endpoint', async (req, res) => {
             job: `${servicePrefix}-server`,
             endpointLabel: spanTag,
             endpoint,
-            message: `traceID=${traceId} endpoint=${endpoint} http.method=GET status=FAILURE err=${err}`,
+            message: `traceID=${traceId} endpoint=${endpoint} http.method=GET status=FAILURE err="${err}"`,
         });
 
         res.status(500).send(err);
@@ -273,7 +272,7 @@ app.delete('/:endpoint', async (req, res) => {
 
     if (!nameSet.includes(endpoint)) {
         res.status(404).send(`${endpoint} is not a valid endpoint`);
-        metricBody.labels.status = "404";
+        metricBody.labels.status = '404';
         responseMetric(metricBody);
         return;
     }
@@ -281,11 +280,11 @@ app.delete('/:endpoint', async (req, res) => {
     if (!req.body || !req.body.name) {
         // Here we'd use 'respondToCall()' which would POST a metric for the response
         // code
-        metricBody.labels.status = "400";
+        metricBody.labels.status = '400';
         responseMetric(metricBody);
     }
 
-    // If we're in the middle of a teardown, don't do anything
+    // If we're in the middle of a tearxdown, don't do anything
     if (teardownCheck({
             spanContext,
             endpoint,
@@ -304,7 +303,7 @@ app.delete('/:endpoint', async (req, res) => {
         });
 
         // Metrics
-        metricBody.labels.status = "204";
+        metricBody.labels.status = '204';
         responseMetric(metricBody);
 
         logEntry({
@@ -319,8 +318,7 @@ app.delete('/:endpoint', async (req, res) => {
         res.sendStatus(204);
     } catch (err) {
         // Metrics
-        console.log(`error: ${err}`);
-        metricBody.labels.status = "500";
+        metricBody.labels.status = '500';
         responseMetric(metricBody);
 
         logEntry({
@@ -329,7 +327,7 @@ app.delete('/:endpoint', async (req, res) => {
             job: `${servicePrefix}-server`,
             endpointLabel: spanTag,
             endpoint,
-            message: `traceID=${traceId} endpoint=${endpoint} http.method=DELETE status=FAILURE err=${err}`,
+            message: `traceID=${traceId} endpoint=${endpoint} http.method=DELETE status=FAILURE err="${err}"`,
         });
 
         res.status(500).send(err);
@@ -338,9 +336,8 @@ app.delete('/:endpoint', async (req, res) => {
 
 // Destroy the DB table and recreate it
 const tableWipe = async () => {
-    const requestSpan = tracer.startSpan("server");
+    const requestSpan = tracer.startSpan('server');
     const { traceId } = requestSpan.spanContext();
-    console.log(traceId);
 
     // Create a new context for this request
     await api.context.with(api.trace.setSpan(api.context.active(), requestSpan), async () => {
@@ -407,7 +404,7 @@ const teardownCheck = (details) => {
 
 // Create the DB and connect to it
 const startServer = async () => {
-    const requestSpan = tracer.startSpan("server");
+    const requestSpan = tracer.startSpan('server');
     // Create a new context for this request
     await api.context.with(api.trace.setSpan(api.context.active(), requestSpan), async () => {
         try {
@@ -453,7 +450,7 @@ const startServer = async () => {
             app.listen(4000);
 
             // Schedule a table wipe in the future.
-            setTimeout(() => tableWipe(), teardownTimeout);
+            setInterval(() => tableWipe(), teardownTimeout);
 
             logEntry({
                 level: 'info',

--- a/tempo/tempo.yaml
+++ b/tempo/tempo.yaml
@@ -1,6 +1,9 @@
 server:
   http_listen_port: 3200
 
+search_enabled: true
+metrics_generator_enabled: true
+
 distributor:
   receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
     jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
@@ -35,11 +38,29 @@ storage:
       encoding: zstd                   # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd
     wal:
       path: /tmp/tempo/wal             # where to store the the wal locally
-      encoding: none                   # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd
+      encoding: snappy                   # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd
     local:
       path: /tmp/tempo/blocks
     pool:
       max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
       queue_depth: 10000
 
-search_enabled: true
+metrics_generator:
+  processor:
+    span_metrics:
+        dimensions:
+          - http.method
+          - http.target
+  registry:
+    collection_interval: 5s
+    external_labels:
+      source: tempo
+      group: 'mythical'
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+overrides:
+  metrics_generator_processors: ['service-graphs', 'span-metrics']


### PR DESCRIPTION
This also cleans some of the code up, and fixes an issue with
table dropping/recreation every 24 hours.

Signed-off-by: Heds Simons <hedley.simons@grafana.com>