### PR TITLE
Remove login form from local docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       - "3000:3000"
     environment:
       - GF_FEATURE_TOGGLES_ENABLE=tempoApmTable flameGraph topnav
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
 
   # The Loki service stores logs sent to it, and takes queries from Grafana
   # to visualise those logs.


### PR DESCRIPTION
This PR sets 3 env vars that removes the login screen when running the local demo. It also sets the anonymous user to be an admin so they can have access to everything inside of their locally running instance.