### PR TITLE
Local docker-compose improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   # The Grafana dashboarding server.
   grafana:
-    image: grafana/grafana:main
+    image: grafana/grafana-dev:9.5.0-102975pre
     volumes:
       - "./grafana/definitions:/var/lib/grafana/dashboards"
       - "./grafana/provisioning:/etc/grafana/provisioning"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   # The Grafana dashboarding server.
   grafana:
-    image: grafana/grafana-dev:9.5.0-102975pre
+    image: grafana/grafana:main
     volumes:
       - "./grafana/definitions:/var/lib/grafana/dashboards"
       - "./grafana/provisioning:/etc/grafana/provisioning"

--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -77,8 +77,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -141,8 +140,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -211,8 +209,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -293,8 +290,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -399,8 +395,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -555,8 +550,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -652,8 +646,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -792,7 +785,7 @@
           "type": "prometheus",
           "uid": "mimir"
         },
-        "definition": "{http_target=~\"(beholder|unicorn|manticore|illithid|owlbear)\"}",
+        "definition": "traces_spanmetrics_calls_total{http_target=~\".*\"}",
         "description": "HTTP Endpont",
         "hide": 0,
         "includeAll": true,
@@ -801,7 +794,7 @@
         "name": "httpEndpoint",
         "options": [],
         "query": {
-          "query": "{http_target=~\"(beholder|unicorn|manticore|illithid|owlbear)\"}",
+          "query": "traces_spanmetrics_calls_total{http_target=~\".*\"}",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -172,7 +172,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.4.0-99069pre",
+      "pluginVersion": "9.5.0-102975pre",
       "targets": [
         {
           "datasource": {
@@ -244,7 +244,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.0-99069pre",
+      "pluginVersion": "9.5.0-102975pre",
       "targets": [
         {
           "datasource": {
@@ -321,9 +321,10 @@
           ],
           "show": false
         },
-        "showHeader": true
+        "showHeader": true,
+        "showRowNums": false
       },
-      "pluginVersion": "9.4.0-99069pre",
+      "pluginVersion": "9.5.0-102975pre",
       "targets": [
         {
           "datasource": {
@@ -446,6 +447,7 @@
         },
         "frameIndex": 0,
         "showHeader": true,
+        "showRowNums": false,
         "sortBy": [
           {
             "desc": true,
@@ -453,7 +455,7 @@
           }
         ]
       },
-      "pluginVersion": "9.4.0-99069pre",
+      "pluginVersion": "9.5.0-102975pre",
       "targets": [
         {
           "datasource": {
@@ -462,7 +464,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "topk(10, sum by (http_method,http_target,service_version)(increase(traces_spanmetrics_latency_sum{http_method=~\".+\", http_target=~\"${httpEndpoint}\",service_version=~\"${serviceVersion}\"}[1m]) / increase(traces_spanmetrics_latency_count{http_method=~\".+\", http_target=~\"${httpEndpoint}\",service_version=~\"${serviceVersion}\"}[1m])))",
+          "expr": "topk(10, sum by (http_method,http_target,service_version)(increase(traces_spanmetrics_latency_sum{http_method=~\".*\", http_target=~\"${httpEndpoint}\",service_version=~\"${serviceVersion}\"}[1m]) / increase(traces_spanmetrics_latency_count{http_method=~\".*\", http_target=~\"${httpEndpoint}\",service_version=~\"${serviceVersion}\"}[1m])))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -592,7 +594,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (http_method,http_target)(increase(traces_spanmetrics_latency_sum{http_method=~\".+\", http_target=~\"${httpEndpoint}\",service_version=~\"${serviceVersion}\"}[10m]) / increase(traces_spanmetrics_latency_count{http_method=~\".+\", http_target=~\"${httpEndpoint}\",service_version=~\"${serviceVersion}\"}[10m]))",
+          "expr": "sum by (http_method,http_target)(increase(traces_spanmetrics_latency_sum{http_method=~\".*\", http_target=~\"${httpEndpoint}\",service_version=~\"${serviceVersion}\"}[10m]) / increase(traces_spanmetrics_latency_count{http_method=~\".*\", http_target=~\"${httpEndpoint}\",service_version=~\"${serviceVersion}\"}[10m]))",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -743,6 +745,7 @@
   "templating": {
     "list": [
       {
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": [
@@ -775,6 +778,7 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": [
@@ -807,6 +811,7 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": [

--- a/grafana/provisioning/datasources/datasources.yaml
+++ b/grafana/provisioning/datasources/datasources.yaml
@@ -38,7 +38,7 @@ datasources:
     jsonData:
       exemplarTraceIdDestinations:
         - datasourceUid: tempo
-          name: traceID
+          name: traceId
       httpMethod: POST
       timeInterval: "2s"
 


### PR DESCRIPTION
- Fixed dashboard expressions
- Fixed exemplar links in the dashboard

I also tried to get the dashboard links to Tempo search to use TraceQL but couldn't get it to work properly.