### PR TITLE
Add Dashboard Tags and Menu to Provisioned Dashboards

### DIFF
--- a/grafana/definitions/mlt-erroring-endpoints.json
+++ b/grafana/definitions/mlt-erroring-endpoints.json
@@ -286,7 +286,10 @@
     "revision": 1,
     "schemaVersion": 38,
     "style": "dark",
-    "tags": [],
+    "tags": [
+      "intro-to-mlt",
+      "mythical-beasts"
+    ],
     "templating": {
       "list": [
         {

--- a/grafana/definitions/mlt-erroring-endpoints.json
+++ b/grafana/definitions/mlt-erroring-endpoints.json
@@ -35,7 +35,7 @@
           "intro-to-mlt"
         ],
         "targetBlank": false,
-        "title": "Intro to MLt Dashboards",
+        "title": "Intro to MLT Dashboards",
         "tooltip": "",
         "type": "dashboards",
         "url": ""

--- a/grafana/definitions/mlt-erroring-endpoints.json
+++ b/grafana/definitions/mlt-erroring-endpoints.json
@@ -25,7 +25,22 @@
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
     "id": 3,
-    "links": [],
+    "links": [
+      {
+        "asDropdown": true,
+        "icon": "external link",
+        "includeVars": false,
+        "keepTime": false,
+        "tags": [
+          "intro-to-mlt"
+        ],
+        "targetBlank": false,
+        "title": "Intro to MLt Dashboards",
+        "tooltip": "",
+        "type": "dashboards",
+        "url": ""
+      }
+    ],
     "liveNow": false,
     "panels": [
       {

--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -34,7 +34,7 @@
         "intro-to-mlt"
       ],
       "targetBlank": false,
-      "title": "Intro to MLt Dashboards",
+      "title": "Intro to MLT Dashboards",
       "tooltip": "",
       "type": "dashboards",
       "url": ""

--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -24,7 +24,22 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [
+        "intro-to-mlt"
+      ],
+      "targetBlank": false,
+      "title": "Intro to MLt Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "liveNow": false,
   "panels": [
     {

--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -739,7 +739,10 @@
   "revision": 1,
   "schemaVersion": 38,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "intro-to-mlt",
+    "mythical-beasts"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
This PR adds two tags to the Dashboards, these are `intro-to-mlt` and `mythical-beasts`. It also adds a Dashboard menu to each of the Dashboards that links to the other Dashboards that contain the `intro-to-mlt` Dashboards.

This improves the Dashboard experience and allows for future Dashboards to be added, and made easily accessible.