### PR TITLE
Specify `$__rate_interval` in mlt.json

### DIFF
--- a/grafana/definitions/mlt.json
+++ b/grafana/definitions/mlt.json
@@ -689,7 +689,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(rate(mythical_request_times_bucket[15s])) by (le, beast))",
+          "expr": "histogram_quantile(0.95, sum(rate(mythical_request_times_bucket[$__rate_interval])) by (le, beast))",
           "interval": "",
           "legendFormat": "{{le}}",
           "range": true,


### PR DESCRIPTION
Updates the `95th Percentile Response Latencies (ms)` Panel to use `$__rate_interval` instead of a hardcoded value of 15s.