### PR TITLE
ci: pin get-vault-secrets action to SHA

### DIFF
--- a/.github/workflows/publish-and-deploy-images.yaml
+++ b/.github/workflows/publish-and-deploy-images.yaml
@@ -99,7 +99,7 @@ jobs:
                     max-parallelism = 2
 
             - name: Retrieve credentials from Vault
-              uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+              uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # get-vault-secrets/v1.2.1
               with:
                 common_secrets: |
                   DOCKERHUB_USERNAME=dockerhub:username


### PR DESCRIPTION
## Summary

- Pins `grafana/shared-workflows/actions/get-vault-secrets` from the mutable tag `get-vault-secrets/v1.2.1` to its full commit SHA (`9f37f656e063f0ad0b0bfc38d49894b57d363936`)
- All other actions in this workflow were already SHA-pinned

Part of Tempo team supply chain hardening (security incident response).

## Test plan

- [ ] CI passes on this PR
- [ ] Confirm pinned SHA resolves to the same tag: `gh api repos/grafana/shared-workflows/git/ref/tags/get-vault-secrets/v1.2.1`