### PR TITLE
ci: publish images to GHCR instead of Docker Hub

### DIFF
--- a/.github/workflows/publish-and-deploy-images.yaml
+++ b/.github/workflows/publish-and-deploy-images.yaml
@@ -16,9 +16,8 @@ jobs:
         permissions:
             contents: read
             packages: write
-            id-token: write
         env:
-            REGISTRY_LOCATION: grafana/intro-to-mltp
+            REGISTRY_LOCATION: ghcr.io/grafana/intro-to-mltp
 
         strategy:
             fail-fast: false
@@ -98,18 +97,12 @@ jobs:
                     [worker.oci]
                     max-parallelism = 2
 
-            - name: Retrieve credentials from Vault
-              uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # get-vault-secrets/v1.2.1
-              with:
-                common_secrets: |
-                  DOCKERHUB_USERNAME=dockerhub:username
-                  DOCKERHUB_PASSWORD=dockerhub:password
-
-            - name: Login to Docker Hub
+            - name: Login to GitHub Container Registry
               uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
               with:
-                username: ${{ env.DOCKERHUB_USERNAME }}
-                password: ${{ env.DOCKERHUB_PASSWORD }}
+                registry: ghcr.io
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Matrix Build and push Mythical images
               uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
@@ -119,7 +112,8 @@ jobs:
                 build-args: |
                   SERVICE=${{ matrix.file_tag.service }}
                 platforms: linux/amd64,linux/arm64
-                outputs: type=registry,push=${{inputs.push_images}}
+                # Only push to the registry on pushes to main; pull request runs build only to validate.
+                push: ${{ github.event_name == 'push' }}
                 tags: |
                   ${{ env.REGISTRY_LOCATION }}:${{ matrix.file_tag.tag_suffix }}-${{ steps.image_tag.outputs.version }}
                   ${{ steps.image_tag.outputs.latest_tag }}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Since the original series, this repository has seen its use grow. Whilst we stil
 
 You can also send data from the example microservice application to Grafana Cloud products.
 
+> [!NOTE]
+> This repository ships a full demo: a sample microservice application (the "Mythical Beasts" services) and a load generator, alongside the complete observability stack, so you can explore metrics, logs, traces and profiles with data flowing out of the box.
+>
+> If you only need an observability backend to send your own application's OpenTelemetry data to, use [`grafana/docker-otel-lgtm`](https://github.com/grafana/docker-otel-lgtm) instead. It bundles the OpenTelemetry Collector, Prometheus, Tempo, Loki, Pyroscope and Grafana into a single container, with no sample application. Reach for it when you have an instrumented app of your own and just want a quick local backend; use this repository when you want a ready-made end-to-end demo.
+
 ## Prerequisites
 
 The following demonstration environment requires:
@@ -69,7 +74,7 @@ The demos from this series were based on the application and code in this reposi
 
 ## Running the Demonstration Environment
 
-Docker Compose will download the required Docker images, before starting the demonstration environment.
+Docker Compose will download the required Docker images, before starting the demonstration environment. The pre-built microservice images are pulled from the GitHub Container Registry (`ghcr.io/grafana/intro-to-mltp`); see [Microservice Source](#microservice-source) for details. These images are no longer published to Docker Hub.
 
 In the following examples, the in-built `compose` command is used with a latest version of Docker (for example, `docker compose up`). If using an older version of Docker with a separate Docker Compose binary, ensure that `docker compose` is replaced with `docker-compose`.
 
@@ -310,6 +315,14 @@ The [`requester`](source/mythical-beasts-requester/index.js) service makes 'rand
 All three services use common code to deal with the [`queue`](source/common/queue.js), [`logging`](source/common/logging.js) and [`tracing`](source/common/tracing.js) requirements they have. The latter is an example of a simple shim API library for utilising the OpenTelemetry SDK in an application.
 
 There is a common [`Dockerfile`](source/docker/Dockerfile) that is used to build all three services.
+
+Pre-built images for the microservice application are published to the GitHub Container Registry (GHCR) under [`ghcr.io/grafana/intro-to-mltp`](https://github.com/grafana/intro-to-mltp/pkgs/container/intro-to-mltp):
+* [`ghcr.io/grafana/intro-to-mltp:mythical-beasts-requester-latest`](https://github.com/grafana/intro-to-mltp/pkgs/container/intro-to-mltp)
+* [`ghcr.io/grafana/intro-to-mltp:mythical-beasts-server-latest`](https://github.com/grafana/intro-to-mltp/pkgs/container/intro-to-mltp)
+* [`ghcr.io/grafana/intro-to-mltp:mythical-beasts-recorder-latest`](https://github.com/grafana/intro-to-mltp/pkgs/container/intro-to-mltp)
+* [`ghcr.io/grafana/intro-to-mltp:mythical-beasts-frontend-latest`](https://github.com/grafana/intro-to-mltp/pkgs/container/intro-to-mltp)
+
+These are the images referenced by the Docker Compose and Kubernetes manifests in this repository. **Note:** New images are no longer published to Docker Hub; the [`docker.io/grafana/intro-to-mltp`](https://hub.docker.com/r/grafana/intro-to-mltp) images are deprecated and will not receive updates. Use the GHCR images above instead. Older tags remain available at [https://hub.docker.com/r/grafana/intro-to-mltp/tags](https://hub.docker.com/r/grafana/intro-to-mltp/tags).
 
 An example pipeline stage in Alloy to rewrite timestamps can be enabled by uncommenting the `TIMESHIFT` environment variable for the `mythical-requester` service. See details in the [Alloy configuration file](alloy/config.alloy).
 

--- a/docker-compose-cloud.yml
+++ b/docker-compose-cloud.yml
@@ -57,7 +57,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-requester
-    image: grafana/intro-to-mltp:mythical-beasts-requester-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-requester-latest
     restart: always
     depends_on:
       mythical-queue:
@@ -84,7 +84,7 @@ services:
     #  args:
     #    - REACT_APP_API_URL=/api
     # By default, this will try and send to Alloy instead of Grafana Cloud Frontend.
-    image: grafana/intro-to-mltp:mythical-beasts-frontend-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-frontend-latest
     restart: always
     depends_on:
       mythical-server:
@@ -104,7 +104,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-server
-    image: grafana/intro-to-mltp:mythical-beasts-server-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-server-latest
     restart: always
     ports:
       - "4000:4000"
@@ -133,7 +133,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-recorder
-    image: grafana/intro-to-mltp:mythical-beasts-recorder-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-recorder-latest
     restart: always
     depends_on:
       mythical-queue:

--- a/docker-compose-otel.yml
+++ b/docker-compose-otel.yml
@@ -63,7 +63,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-requester
-    image: grafana/intro-to-mltp:mythical-beasts-requester-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-requester-latest
     restart: always
     depends_on:
       mythical-queue:
@@ -91,7 +91,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-server
-    image: grafana/intro-to-mltp:mythical-beasts-server-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-server-latest
     restart: always
     ports:
       - "4000:4000"
@@ -115,7 +115,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-recorder
-    image: grafana/intro-to-mltp:mythical-beasts-recorder-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-recorder-latest
     restart: always
     depends_on:
       mythical-queue:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-requester
-    image: grafana/intro-to-mltp:mythical-beasts-requester-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-requester-latest
     restart: always
     depends_on:
       mythical-queue:
@@ -103,7 +103,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-server
-    image: grafana/intro-to-mltp:mythical-beasts-server-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-server-latest
     restart: always
     ports:
       - "4000:4000"
@@ -132,7 +132,7 @@ services:
     #  dockerfile: docker/Dockerfile
     #  args:
     #    SERVICE: mythical-beasts-recorder
-    image: grafana/intro-to-mltp:mythical-beasts-recorder-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-recorder-latest
     restart: always
     depends_on:
       mythical-queue:
@@ -156,7 +156,7 @@ services:
     #  dockerfile: Dockerfile
     #  args:
     #    - REACT_APP_API_URL=/api
-    image: grafana/intro-to-mltp:mythical-beasts-frontend-latest
+    image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-frontend-latest
     restart: always
     depends_on:
       mythical-server:

--- a/k8s/mythical/mythical-beasts-deployment.yaml
+++ b/k8s/mythical/mythical-beasts-deployment.yaml
@@ -47,7 +47,7 @@ spec:
               fieldPath: status.podIP
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: ip=$(POD_IP)
-        image: grafana/intro-to-mltp:mythical-beasts-requester-latest
+        image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-requester-latest
         imagePullPolicy: Always
         name: mythical-requester
         resources: {}
@@ -105,7 +105,7 @@ spec:
               fieldPath: status.podIP
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: ip=$(POD_IP)
-        image: grafana/intro-to-mltp:mythical-beasts-server-latest
+        image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-server-latest
         imagePullPolicy: Always
         name: mythical-server
         ports:
@@ -164,7 +164,7 @@ spec:
               fieldPath: status.podIP
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: ip=$(POD_IP)
-        image: grafana/intro-to-mltp:mythical-beasts-recorder-latest
+        image: ghcr.io/grafana/intro-to-mltp:mythical-beasts-recorder-latest
         imagePullPolicy: Always
         name: mythical-recorder
         resources: {}


### PR DESCRIPTION
Move publishing of the demo microservice images to the GitHub Container Registry (`ghcr.io/grafana/intro-to-mltp`) using the built-in `GITHUB_TOKEN`, and update the docs to match.